### PR TITLE
feat(refund): SDK para estornos de Transações

### DIFF
--- a/src/Contracts/Features/RefundsContract.php
+++ b/src/Contracts/Features/RefundsContract.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Liuv\Larapix\Contracts\Features;
+
+use Liuv\Larapix\ValueObjects\Refund;
+
+interface RefundsContract
+{
+
+    public function findById(string $refundId): array;
+
+    public function findAll(array $parameters = []): array;
+
+    public function create(Refund $refund): array;
+}

--- a/src/Contracts/LarapixContract.php
+++ b/src/Contracts/LarapixContract.php
@@ -3,8 +3,11 @@
 namespace Liuv\Larapix\Contracts;
 
 use Liuv\Larapix\Contracts\Features\ChargesContract;
+use Liuv\Larapix\Contracts\Features\RefundsContract;
 
 interface LarapixContract
 {
     public function charges(): ChargesContract;
+
+    public function refunds(): RefundsContract;
 }

--- a/src/LarapixService.php
+++ b/src/LarapixService.php
@@ -4,8 +4,10 @@ namespace Liuv\Larapix;
 
 use GuzzleHttp\Client;
 use Liuv\Larapix\Contracts\Features\ChargesContract;
+use Liuv\Larapix\Contracts\Features\RefundsContract;
 use Liuv\Larapix\Contracts\LarapixContract;
 use Liuv\Larapix\Services\ChargesService;
+use Liuv\Larapix\Services\RefundsService;
 
 class LarapixService implements LarapixContract
 {
@@ -22,5 +24,10 @@ class LarapixService implements LarapixContract
     public function charges(): ChargesContract
     {
         return new ChargesService($this->client);
+    }
+
+    public function refunds(): RefundsContract
+    {
+        return new RefundsService($this->client);
     }
 }

--- a/src/Services/RefundsService.php
+++ b/src/Services/RefundsService.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Liuv\Larapix\Services;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Exception\ClientException;
+use Liuv\Larapix\Contracts\Features\RefundsContract;
+use Liuv\Larapix\ValueObjects\Refund;
+
+class RefundsService implements RefundsContract
+{
+
+    const BASE_API = 'https://api.openpix.com.br/api/openpix/v1';
+
+    private $client;
+
+    public function __construct(Client $client)
+    {
+        $this->client = $client;
+    }
+
+
+    public function findById(string $refundId): array
+    {
+        $uri = sprintf(self::BASE_API . '/refund/%s', $refundId);
+
+        $response = $this->client->get($uri);
+
+        return json_decode($response->getBody(), true);
+    }
+
+    public function findAll(array $parameters = []): array
+    {
+        $uri = self::BASE_API . '/refund';
+
+        $response = $this->client->get($uri);
+
+        return json_decode($response->getBody(), true);
+    }
+
+    public function create(Refund $refund): array
+    {
+        
+        $uri = self::BASE_API . '/refund';
+        $response = $this->client->post($uri, [
+            'headers' => [
+                'Content-Type' => 'application/json',
+                'Accept' => 'application/json',
+            ],
+            'body' => json_encode($refund)
+        ]);
+        // TODO: decide how to differentiate any type of error
+
+        return json_decode($response->getBody(), true);
+    }
+}

--- a/src/ValueObjects/Refund.php
+++ b/src/ValueObjects/Refund.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Liuv\Larapix\ValueObjects;
+
+
+class Refund implements \JsonSerializable
+{
+    private $transactionEndToEndId;
+
+    private $correlationId;
+
+    private $value;
+
+    public function __construct(
+        string $correlationId, 
+        string $transactionEndToEndId, 
+        int $value
+    )
+    {
+        $this->corretionId = $correlationId;
+        $this->transactionEndToEndId = $transactionEndToEndId;
+        $this->value = $value;
+    }
+
+
+    public function jsonSerialize(): array
+    {
+        return [
+            'correlationID' => $this->corretionId,
+            'transactionEndToEndId' => $this->transactionEndToEndId,
+            'value' => $this->value,
+        ];
+    }
+}

--- a/tests/LarapixServiceTest.php
+++ b/tests/LarapixServiceTest.php
@@ -5,6 +5,7 @@ namespace Liuv\Tests;
 use GuzzleHttp\Client;
 use GuzzleHttp\ClientInterface;
 use Liuv\Larapix\Contracts\Features\ChargesContract;
+use Liuv\Larapix\Contracts\Features\RefundsContract;
 use Liuv\Larapix\Contracts\LarapixContract;
 use Liuv\Larapix\LarapixService;
 use PHPUnit\Framework\TestCase;
@@ -28,5 +29,11 @@ class LarapixServiceTest extends TestCase
     {
         $this->assertInstanceOf(LarapixContract::class, $this->service);
         $this->assertInstanceOf(ChargesContract::class, $this->service->charges());
+    }
+
+    public function test_larapix_refund_function()
+    {
+        $this->assertInstanceOf(LarapixContract::class, $this->service);
+        $this->assertInstanceOf(RefundsContract::class, $this->service->refunds());
     }
 }

--- a/tests/Services/RefundServiceTest.php
+++ b/tests/Services/RefundServiceTest.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace Liuv\Tests\Services;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Response;
+
+use Liuv\Larapix\Contracts\Features\RefundsContract;
+use Liuv\Larapix\Services\RefundsService;
+use Liuv\Larapix\ValueObjects\Charge;
+use PHPUnit\Framework\TestCase;
+
+class RefundServiceTest extends TestCase
+{
+
+    public function test_charges_contract()
+    {
+        $this->assertInstanceOf(RefundsContract::class, new RefundsService(new Client()));
+    }
+
+    public function test_fetch_refund()
+    {
+        // Prepare
+        $mock = new MockHandler([new Response(200, [], json_encode($this->expectedFetchObject()))]);
+        $handlerStack = HandlerStack::create($mock);
+        $client = new Client(['handler' => $handlerStack]);
+        $id = 'artur-me-da-um-aumento';
+        $this->service = new RefundsService($client);
+
+        // Act
+        $actual = $this->service->findById($id);
+
+        // Assert
+        $this->assertTrue(method_exists($this->service, 'findById'));
+        $this->assertEquals($this->expectedFetchObject(), $actual);
+    }
+
+    public function test_fetch_refunds()
+    {
+        // Prepare
+        $mock = new MockHandler([new Response(200, [], json_encode($this->expectedFetchObjects()))]);
+        $handlerStack = HandlerStack::create($mock);
+        $client = new Client(['handler' => $handlerStack]);
+        $this->service = new RefundsService($client);
+        $parameters = [];
+        
+        // Act
+        $actual = $this->service->findAll($parameters);
+
+        // Assert
+        $this->assertTrue(method_exists($this->service, 'findAll'));
+        $this->assertEquals($this->expectedFetchObjects(), $actual);
+    }
+
+    public function test_create_refund()
+    {
+        // Prepare
+        $mock = new MockHandler([new Response(200, [], json_encode($this->expectedRefundObject()))]);
+        $handlerStack = HandlerStack::create($mock);
+        $client = new Client(['handler' => $handlerStack]);
+        $this->service = new RefundsService($client);
+        $parameters = [];
+        
+        // Act
+        $actual = $this->service->findAll($parameters);
+
+        // Assert
+        $this->assertTrue(method_exists($this->service, 'create'));
+        $this->assertEquals($this->expectedRefundObject(), $actual);
+    }
+
+    public function expectedFetchObject()
+    {
+        return  [
+            "refund" => [
+                "value" => 100,
+                "correlationID" => "7777-6f71-427a-bf00-241681624586",
+                "refundId" => "11bf5b37e0b842e08dcfdc8c4aefc000",
+                "returnIdentification" => "D09089356202108032000a543e325902"
+            ]
+        ];
+    }
+    public function expectedRefundObject()
+    {
+        return  [
+            "refund" => [
+                "value" => 100,
+                "correlationID" => "7777-6f71-427a-bf00-241681624586",
+                "refundId" => "11bf5b37e0b842e08dcfdc8c4aefc000",
+                "returnIdentification" => "D09089356202108032000a543e325902"
+            ]
+        ];
+    }
+
+    public function expectedFetchObjects()
+    {
+        return [
+            "pageInfo" => [
+                "skip" => 0,
+                "limit" => 10,
+                "totalCount" => 20,
+                "hasPreviousPage" => false,
+                "hasNextPage" => true
+            ],
+            "refunds" => [
+                "status" => "IN_PROCESSING",
+                "value" => 100,
+                "correlationID" => "9134e286-6f71-427a-bf00-241681624586",
+                "refundId" => "9134e2866f71427abf00241681624586",
+                "time" => "2021-03-02T17:28:51.882Z"
+            ]
+        ];
+    }
+}


### PR DESCRIPTION
# Changelog

Adicionado serviço para consumo de API's de estorno do OpenPix.

```php

$service = new LarapixService();

// Criar estorno
$refund = new Refund('correlation-id-da-transação', "id-end-to-end-da-transação", 1);
$service->refunds()->create($refund);

// Buscar estorno especifico
$service->refunds()->findById('id-da-transação');


// Buscar estornos paginados
$service->refunds()->findAll([]);

```

### Mudanças
*  Adicionado listagem de estornos;
*  Adicionado busca de um estorno por ID
*  Adicionado criação de um estorno
*  Object Value para Estorno

