### PR TITLE
refactor: Create a BaseService class containing a default success

### DIFF
--- a/src/Services/BaseService.php
+++ b/src/Services/BaseService.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Liuv\Larapix\Services;
+
+abstract class BaseService
+{
+    protected function success(string $body): array
+    {
+        return json_decode($body, true);
+    }
+}

--- a/src/Services/ChargesService.php
+++ b/src/Services/ChargesService.php
@@ -9,7 +9,7 @@ use Liuv\Larapix\Exceptions\ChargeAlreadyCreatedException;
 use Liuv\Larapix\Exceptions\ChargeNotFoundException;
 use Liuv\Larapix\ValueObjects\Charge;
 
-class ChargesService implements ChargesContract
+class ChargesService extends BaseService implements ChargesContract
 {
     const BASE_API = 'https://api.openpix.com.br/api/openpix/v1';
     /**
@@ -35,7 +35,7 @@ class ChargesService implements ChargesContract
             );
         }
 
-        return json_decode($response->getBody(), true);
+        return $this->success($response->getBody());
     }
 
     public function findAll(array $params = []): array
@@ -43,7 +43,7 @@ class ChargesService implements ChargesContract
         $uri = self::BASE_API . '/charge';
         $response = $this->client->get($uri);
 
-        return json_decode($response->getBody(), true);
+        return $this->success($response->getBody());
     }
 
     public function create(Charge $charge): array
@@ -65,6 +65,6 @@ class ChargesService implements ChargesContract
             );
         }
 
-        return json_decode($response->getBody(), true);
+        return $this->success($response->getBody());
     }
 }

--- a/src/Services/PaymentsService.php
+++ b/src/Services/PaymentsService.php
@@ -7,7 +7,7 @@ use Liuv\Larapix\Contracts\Features\PaymentsContract;
 use Liuv\Larapix\ValueObjects\Payment\Pix;
 use Liuv\Larapix\ValueObjects\Payment\QrCode;
 
-class PaymentsService implements PaymentsContract
+class PaymentsService extends BaseService implements PaymentsContract
 {
     const BASE_API = 'https://api.openpix.com.br/api/openpix/v1/pay';
     /**
@@ -32,7 +32,7 @@ class PaymentsService implements PaymentsContract
         ]);
         // TODO: decide how to differentiate any type of error
 
-        return json_decode($response->getBody(), true);
+        return $this->success($response->getBody());
     }
 
     public function initQrCodePayment(QrCode $qrCode): array
@@ -47,7 +47,7 @@ class PaymentsService implements PaymentsContract
         ]);
         // TODO: decide how to differentiate any type of error
 
-        return json_decode($response->getBody(), true);
+        return $this->success($response->getBody());
     }
 
     public function confirmPayment(string $paymentCorrelationId): array
@@ -64,6 +64,6 @@ class PaymentsService implements PaymentsContract
         ]);
         // TODO: decide how to differentiate any type of error
 
-        return json_decode($response->getBody(), true);
+        return $this->success($response->getBody());
     }
 }

--- a/src/Services/RefundsService.php
+++ b/src/Services/RefundsService.php
@@ -7,7 +7,7 @@ use GuzzleHttp\Exception\ClientException;
 use Liuv\Larapix\Contracts\Features\RefundsContract;
 use Liuv\Larapix\ValueObjects\Refund;
 
-class RefundsService implements RefundsContract
+class RefundsService extends BaseService implements RefundsContract
 {
     const BASE_API = 'https://api.openpix.com.br/api/openpix/v1';
 
@@ -25,7 +25,7 @@ class RefundsService implements RefundsContract
 
         $response = $this->client->get($uri);
 
-        return json_decode($response->getBody(), true);
+        return $this->success($response->getBody());
     }
 
     public function findAll(array $parameters = []): array
@@ -34,7 +34,7 @@ class RefundsService implements RefundsContract
 
         $response = $this->client->get($uri);
 
-        return json_decode($response->getBody(), true);
+        return $this->success($response->getBody());
     }
 
     public function create(Refund $refund): array
@@ -50,6 +50,6 @@ class RefundsService implements RefundsContract
         ]);
         // TODO: decide how to differentiate any type of error
 
-        return json_decode($response->getBody(), true);
+        return $this->success($response->getBody());
     }
 }

--- a/src/Services/TransactionsService.php
+++ b/src/Services/TransactionsService.php
@@ -5,7 +5,7 @@ namespace Liuv\Larapix\Services;
 use GuzzleHttp\Client;
 use Liuv\Larapix\Contracts\Features\TransactionContract;
 
-class TransactionsService implements TransactionContract
+class TransactionsService extends BaseService implements TransactionContract
 {
     const BASE_API = 'https://api.openpix.com.br/api/openpix/v1';
     /**
@@ -26,7 +26,7 @@ class TransactionsService implements TransactionContract
         );
         $response = $this->client->get($uri);
 
-        return json_decode($response->getBody(), true);
+        return $this->success($response->getBody());
     }
 
     public function findAll(array $parameters = []): array
@@ -35,6 +35,6 @@ class TransactionsService implements TransactionContract
 
         $response = $this->client->get($uri);
 
-        return json_decode($response->getBody(), true);
+        return $this->success($response->getBody());
     }
 }


### PR DESCRIPTION
# Changelog
Added a new BaseService class with a default success method. Enabling us to add more abstraction in further implementation.

```php
<?php

namespace Liuv\Larapix\Services;

abstract class BaseService
{
    protected function success(string $body): array
    {
        return json_decode($body, true);
    }
}

```
## Tests
All current tests are passing. I did not see any additional test that could be implemented.